### PR TITLE
Handle space-padded software numbers in SystemRevision

### DIFF
--- a/lib/atg/objects/system_revision.rb
+++ b/lib/atg/objects/system_revision.rb
@@ -7,9 +7,11 @@ module Atg
     attr_accessor :software_number, :base_number, :version, :revision, :created_at
 
     # data is the results portion after the command echo + timestamp,
-    # e.g. "SOFTWARE# 346321-100-ACREATED - 12.02.24.10.05"
+    # e.g. "SOFTWARE# 346321-100-ACREATED - 12.02.24.10.05".
+    # Some devices pad the software number with spaces before CREATED,
+    # e.g. "SOFTWARE# 346020-100-D  CREATED - 01.12.17.15.01"
     def initialize(data)
-      software = data[/SOFTWARE#\s*(\S+?)(?=CREATED)/, 1]
+      software = data[/SOFTWARE#\s*(\S+?)\s*(?=CREATED)/, 1]
       @software_number = software
 
       if software && (parts = software.split("-")).size >= 3

--- a/test/reports/system_revision_report_test.rb
+++ b/test/reports/system_revision_report_test.rb
@@ -15,4 +15,15 @@ class SystemRevisionReportTest < Minitest::Test
     assert_equal "A", entry.revision
     assert_equal DateTime.new(2012, 2, 24, 10, 5), entry.created_at
   end
+
+  # Captured from a live TLS-350 — software number is space-padded before CREATED
+  def test_system_revision_with_padded_software_number
+    entry = Atg::SystemRevision.new("SOFTWARE# 346020-100-D  CREATED - 01.12.17.15.01")
+
+    assert_equal "346020-100-D", entry.software_number
+    assert_equal "346020", entry.base_number
+    assert_equal "100", entry.version
+    assert_equal "D", entry.revision
+    assert_equal DateTime.new(2001, 12, 17, 15, 1), entry.created_at
+  end
 end


### PR DESCRIPTION
## Problem
First live-hardware run of `i90200` (TLS-350 at a production site, software `346020-100-D`) returned `software_number: nil`. The device pads the software number with spaces before `CREATED`:

```
SOFTWARE# 346020-100-D  CREATED - 01.12.17.15.01
```

The regex lookahead `(\S+?)(?=CREATED)` required `CREATED` to be glued directly to the number (as in the synthetic fixture), so the match failed on padded responses.

## Fix
Allow optional whitespace before the lookahead: `(\S+?)\s*(?=CREATED)`. Glued fixture still parses identically.

## Verification
- New test with the captured live response: `346020-100-D` → base `346020`, version `100`, revision `D`, created 2001-12-17 15:01
- Suite: 40 runs, 421 assertions, 0 failures (up from 39)
- `standardrb`: no new offenses (one pre-existing in `examples/telnet.rb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)