### PR TITLE
Guard parse_timestamp against garbled TLS-350 stamps (return nil, don't raise)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+- Guard `Base#parse_timestamp` against garbled TLS-350 frames: an unparseable
+  10-digit stamp now returns `nil` instead of raising `ArgumentError` and
+  sinking the whole report (matches `SystemRevision#parse_created`).
+- Restore the mangled `# frozen_string_literal: true` magic comment in
+  `lib/atg/base.rb`.
+
 ## [0.1.0] - 2022-05-07
 
 - Initial release

--- a/lib/atg/base.rb
+++ b/lib/atg/base.rb
@@ -1,9 +1,13 @@
-# frozen_strirequire "date"
+# frozen_string_literal: true
 
 require "date"
 
 module Atg
   class Base
+    # Parses a 10-digit YYMMDDHHmm stamp. Some live TLS-350 frames carry a
+    # garbled stamp (bad month/day, stray characters); one unparseable stamp
+    # must not raise and sink the whole report, so return nil — matching
+    # SystemRevision#parse_created.
     def parse_timestamp(timestamp)
       year = timestamp[0..1].to_i
 
@@ -20,6 +24,8 @@ module Atg
       minute = timestamp[8..9].to_i
 
       DateTime.new(year, month, day, hour, minute)
+    rescue ArgumentError
+      nil
     end
 
     def ieee754_value(hex_value)

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaseTest < Minitest::Test
+  def setup
+    @base = Atg::Base.new
+  end
+
+  def test_parse_timestamp_parses_a_valid_stamp
+    assert_equal DateTime.new(2026, 6, 11, 10, 15), @base.parse_timestamp("2606111015")
+  end
+
+  def test_parse_timestamp_handles_20th_century_years
+    assert_equal DateTime.new(1998, 3, 4, 5, 6), @base.parse_timestamp("9803040506")
+  end
+
+  def test_parse_timestamp_returns_nil_for_a_garbled_stamp
+    # A live TLS-350 frame with a month/day of 00 must not raise ArgumentError
+    # and sink the whole report — responded_at just comes back nil.
+    assert_nil @base.parse_timestamp("2600000000")
+  end
+end


### PR DESCRIPTION
## Problem

`Base#parse_timestamp` calls `DateTime.new(year, month, day, hour, minute)` **unguarded**. Some live TLS-350 frames carry a garbled 10-digit timestamp (e.g. a month/day of `00`, or stray non-numeric characters), which makes `DateTime.new` raise `ArgumentError: invalid date`.

`parse_timestamp` runs inside `Report#process` (`@responded_at = parse_timestamp(@response[6..15])`), so that exception propagates out of `Report#run` and **sinks the entire report** — not just the timestamp.

This showed up in production (pass-tools ATG config snapshots): the last Sunday run logged `invalid date` on **~22 devices' `i90200` (System Revision) frames**, each failing the whole command and marking the snapshot partial/failed even though the software-number/revision data in the frame was perfectly parseable.

Its sibling `SystemRevision#parse_created` already guards the same way (`rescue ArgumentError` → `nil`); `parse_timestamp` should match.

## Change

- `parse_timestamp` now returns `nil` for an unparseable stamp instead of raising. `responded_at` (and any object timestamp field) comes back `nil` and the rest of the report parses normally — `nil` is already an accepted value here, exactly like `parse_created`.
- Restored the mangled magic comment in `lib/atg/base.rb` — line 1 was `# frozen_strirequire "date"` (a botched edit), now `# frozen_string_literal: true`. No behavior change; the method bodies don't mutate string literals.

## Tests

New `test/base_test.rb`: valid stamp, 20th-century year branch, and a garbled stamp returning `nil`. Full suite green (43 runs, 424 assertions, 0 failures) under the pinned Ruby 3.4.2; `standardrb` clean.