### PR TITLE
Revert parse_timestamp garbled-stamp guard (it masked gateway timeouts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## [Unreleased]
 
-- Guard `Base#parse_timestamp` against garbled TLS-350 frames: an unparseable
-  10-digit stamp now returns `nil` instead of raising `ArgumentError` and
-  sinking the whole report (matches `SystemRevision#parse_created`).
 - Restore the mangled `# frozen_string_literal: true` magic comment in
   `lib/atg/base.rb`.
 

--- a/lib/atg/base.rb
+++ b/lib/atg/base.rb
@@ -4,10 +4,13 @@ require "date"
 
 module Atg
   class Base
-    # Parses a 10-digit YYMMDDHHmm stamp. Some live TLS-350 frames carry a
-    # garbled stamp (bad month/day, stray characters); one unparseable stamp
-    # must not raise and sink the whole report, so return nil — matching
-    # SystemRevision#parse_created.
+    # Parses a 10-digit YYMMDDHHmm stamp into a DateTime. A malformed stamp
+    # raises ArgumentError ("invalid date"). A real device frame always carries
+    # a valid timestamp, so an unparseable one signals the frame isn't a real
+    # device response (e.g. a gateway failure marker that echoes the command
+    # code) — the caller should treat it as a failed command rather than let
+    # the garbage parse into results. (An earlier guard swallowed this to nil,
+    # which masked exactly those timeouts, so it was reverted.)
     def parse_timestamp(timestamp)
       year = timestamp[0..1].to_i
 
@@ -24,8 +27,6 @@ module Atg
       minute = timestamp[8..9].to_i
 
       DateTime.new(year, month, day, hour, minute)
-    rescue ArgumentError
-      nil
     end
 
     def ieee754_value(hex_value)

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -15,9 +15,10 @@ class BaseTest < Minitest::Test
     assert_equal DateTime.new(1998, 3, 4, 5, 6), @base.parse_timestamp("9803040506")
   end
 
-  def test_parse_timestamp_returns_nil_for_a_garbled_stamp
-    # A live TLS-350 frame with a month/day of 00 must not raise ArgumentError
-    # and sink the whole report — responded_at just comes back nil.
-    assert_nil @base.parse_timestamp("2600000000")
+  def test_parse_timestamp_raises_on_a_garbled_stamp
+    # A garbled stamp (month/day 00) must raise so the caller rejects the frame
+    # instead of parsing garbage — a real device frame always has a valid
+    # timestamp, so an unparseable one means the response isn't a real frame.
+    assert_raises(ArgumentError) { @base.parse_timestamp("2600000000") }
   end
 end


### PR DESCRIPTION
Reverts the `parse_timestamp` guard from #6.

## Why

#6 made `parse_timestamp` `rescue ArgumentError` → `nil`, on the theory that ~22 devices had valid System Revision frames with a garbled timestamp. That was a **misdiagnosis**: in production those `i90200` "invalid date" cases were all the MyTankInfo gateway's **poll-failure marker** —

```
i90200..Poll Failed..no data returned
```

— not real frames. The marker **echoes the command code**, so it passes the parser's command-match check; the garbled "timestamp" raising `ArgumentError` was the *only* thing rejecting it. Swallowing that to `nil` let the marker parse into garbage config (false "config changed" diffs + notifications downstream).

A real device frame **always** carries a valid 10-digit timestamp, so an unparseable one is a reliable signal the response isn't a real frame. Restoring the raise makes the caller treat it as a failed command.

## Change

- `parse_timestamp` raises `ArgumentError` again on a malformed stamp (guard removed).
- Its test now asserts the raise.
- **Kept** the `# frozen_string_literal: true` magic-comment fix from #6 (that file was genuinely corrupted; not reverting it).

The downstream gateway marker is also now filtered in the consuming app (pass/pass-tools#3718), so this is defense-in-depth: any *other* malformed frame that echoes a command code is rejected here rather than parsed into garbage.

Suite green (43 runs), standardrb clean, under the pinned Ruby 3.4.2.